### PR TITLE
Add dnspython to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pymongo==3.11.2
 python-dotenv==0.19.2
+dnspython
 sqlmodel
 psycopg2


### PR DESCRIPTION
`dnspython` needs to be installed for the python script to run properly.
In this PR, we are adding the package to `requirements.txt`