### PR TITLE
add family_members

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 from pydantic import validator
 from sqlalchemy import Column
 from sqlmodel import Field, SQLModel, JSON
@@ -38,7 +38,7 @@ class Products(SQLModel, table=True):
 
 class Families(SQLModel, table=True):
     family_id: str = Field(default=None, primary_key=True, alias='_id')
-    # family_member_id: dict = Field(sa_column=Column(JSON))
+    family_members: List[str]
     name: str
     city: str
     housing_details: Optional[str]
@@ -52,6 +52,10 @@ class Families(SQLModel, table=True):
     @validator("family_id", pre=True)
     def unnest_id(cls, v):
         return v["$oid"]
+
+    @validator("family_members", pre=True)
+    def unnest_family_members(cls, v):
+        return [fm["$oid"] for fm in v]
 
     @validator("created_at", "updated_at", "last_visit_at", pre=True)
     def unnest_date(cls, v):
@@ -108,5 +112,3 @@ class VisitEvents(SQLModel, table=True):
         allow_population_by_field_name = True
 
 # class Categories
-
-


### PR DESCRIPTION
just to unblock you

here is the script to test this in the REPL

```python
import json
from models import Families

table_name = "families"
fh = open(f"data/{table_name}.jsonl", "r")
p = fh.readline()
Families(id=1, **json.loads(p))
```
returns
```txt
 Families(family_id='6193f29bc309ae001611b589', family_members=['61b73f82f30143001605b847', '61b73f82f30143001605b848', '61b73f83f30143001605b849', '61b73f83f30143001605b84a'], name='Abbache', city='Malakoff', housing_details='', created_at=datetime.datetime(2021, 11, 16, 18, 4, 11, 614000, tzinfo=datetime.timezone.utc), updated_at=datetime.datetime(2022, 1, 29, 10, 53, 28, 754000, tzinfo=datetime.timezone.utc), additional_info='', last_visit_at=datetime.datetime(2022, 1, 29, 10, 53, 28, 754000, tzinfo=datetime.timezone.utc), know_association_by=None, certificate_of_residence_provided_at=None)
```

you'll have to turn that into a Relationship.

Note: for the Relationship to work, you might need to add to the same DB session the families rows and the family_members rows before committing. Or if that's too annoying, you might need instead to extract "family_members" **before** "families".