### PR TITLE
Extract 7 days operations

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,19 +20,20 @@ orm_classes = {
 }
 
 
-def extract(table_name: str):
+def extract(collection_name: str):
     """Extract data from MongoDB to local JSONLine file.
 
     Ref: https://realpython.com/introduction-to-mongodb-and-python/
     """
     client = pymongo.MongoClient(os.environ.get("MONGO_DB"))
     db = client.porteBleue  # use porteBleue
-    table = db[table_name]  # db.getCollection("products")
-    with open(f"data/{table_name}.jsonl", "w") as fh:
-        if table_name == 'operations':
-            fh.writelines([dumps(doc) + "\n" for doc in table.find({"createdAt":{"$gte":datetime.today() - timedelta(7)}})]) # Limit the extract to last 7 days of  for operations table
+    collection = db[collection_name]  # db.getCollection("products")
+
+    with open(f"data/{collection_name}.jsonl", "w") as fh:
+        if collection_name == 'operations':
+            fh.writelines([dumps(doc) + "\n" for doc in collection.find({"createdAt":{"$gte":datetime.today() - timedelta(7)}})]) # Limit the extract to last 7 days from the `operations` collection
         else:
-            fh.writelines([dumps(doc) + "\n" for doc in table.find()])
+            fh.writelines([dumps(doc) + "\n" for doc in collection.find()])
 
 
 def load(table_name: str):
@@ -64,7 +65,7 @@ if __name__ == "__main__":
         "operations"
     ]
     for t in tables_to_extract:
-        print(f"extracting table: {t}")
-        extract(table_name=t)
+        print(f"extracting collection: {t}")
+        extract(collection_name=t)
         print(f"loading table: {t}")
         load(table_name=t)


### PR DESCRIPTION
The `operations` collection in mongodb is holding close to 10k documents.
As [Heroku Postgres free plan](https://elements.heroku.com/addons/heroku-postgresql) has a limit of 10k rows, we should not extract the entire `operations` collection. In this PR, we are limiting the extract of the `operations` data to the last 7 days (less than 1k rows per week) to make sure we are not hitting the row limit.