### PR TITLE
Add total_people_helped to family members report

### DIFF
--- a/dbt-models/models/food_bank_report/viz_food_bank_report__family_members__quarterly.sql
+++ b/dbt-models/models/food_bank_report/viz_food_bank_report__family_members__quarterly.sql
@@ -18,6 +18,7 @@ family_members_by_quarter as (
     select
         date_trunc('quarter', visit_date)::date as quarter,
         family_id,
+        family_member_id,
         gender,
         case
             when age >= 0 and age <= 3 then '0 to 3'
@@ -26,9 +27,9 @@ family_members_by_quarter as (
             when age >= 26 and age <= 64 then '16 to 64'
             when age >= 65 then '65+'
         end as age_range,
-        count(distinct family_member_id) as number_of_people_helped
+        count(family_member_id) as total_people_helped
     from calculate_age
-    group by 1,2,3,4
+    group by 1,2,3,4,5
 
 ),
 
@@ -38,7 +39,8 @@ grouped as (
         quarter,
         gender,
         age_range,
-        sum(number_of_people_helped) as number_of_people_helped
+        count(family_member_id) as unique_people_helped,
+        sum(total_people_helped) as number_of_people_helped
     from family_members_by_quarter
     group by 1,2,3
 


### PR DESCRIPTION
<img width="598" alt="Screenshot 2022-04-07 at 07 46 00" src="https://user-images.githubusercontent.com/49002487/162128808-66469a4d-4723-43ea-9b3c-728f85174329.png">

The Food Bank report requires both the number of unique individuals assisted during the period as well as the total number of recipients (a person receiving assistance more than once should be counted more than once).

In this PR, we are adding `total_people_helped` to `viz_food_bank_report__family_members__quarterly` and we are renaming `number_of_people_helped` as `unique_people_helped`.
